### PR TITLE
Create readme in main directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+Cstitch
+=======
+
+Cstitch is a free and open source program for creating cross stitch patterns from images.
+
+See [our sourceforge page](http://cstitch.sourceforge.net/) for more details and documentation.


### PR DESCRIPTION
When GitHub finds a markdown-formatted readme file, it displays it on the front page of the project. Adding this file means that users accustomed to GitHub workflow are likelier to find the project's documentation when glancing at it, since this is the location where one expects to find that information.

I know this because I didn't find the "real" documentation till my third day trying to use the project, because I automatically assumed a project on github would have a link to its docs in the readme, whereas your docs link was hiding in plain site in the project description... :persevere: 
