### PR TITLE
Support for 1-1 squaring option

### DIFF
--- a/colorCompare.cpp
+++ b/colorCompare.cpp
@@ -40,7 +40,7 @@
 #include "xmlUtility.h"
 
 // min/max user-selectable square sizes
-extern const int SQUARE_SIZE_MIN = 2;
+extern const int SQUARE_SIZE_MIN = 1;
 extern const int SQUARE_SIZE_MAX = 50;
 
 colorCompare::colorCompare(const QImage& image, int index,


### PR DESCRIPTION
Previously there wasn't possible to select less than 2 in the
colour chooser menu. When you have a already have pixel art ready its
nice to not have to scale it up before using Cstitch.
This fixes a existing feature request:
http://sourceforge.net/p/cstitch/feature-requests/3/